### PR TITLE
Preserve CursorStack when switching Tabs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.7
 
 # Mod Properties
-	mod_version = 0.9.beta-1.19.x
+	mod_version = 0.9.0-beta-1.19.x
 	maven_group = com.kqp
 	archives_base_name = inventorytabs
 

--- a/src/main/java/com/kqp/inventorytabs/tabs/TabManager.java
+++ b/src/main/java/com/kqp/inventorytabs/tabs/TabManager.java
@@ -77,10 +77,14 @@ public class TabManager {
             }
         }
 
-        // Add new tabs
-        TabProviderRegistry.getTabProviders().forEach(tabProvider -> {
-            tabProvider.addAvailableTabs(MinecraftClient.getInstance().player, tabs);
-        });
+        ClientPlayerEntity player = MinecraftClient.getInstance().player;
+
+        if (player != null && player.isAlive()) {
+            // Add new tabs
+            TabProviderRegistry.getTabProviders().forEach(tabProvider -> {
+                tabProvider.addAvailableTabs(player, tabs);
+            });
+        }
 
         if (currentTab != null) {
             for (int i = 0; i < tabs.size(); i++) {

--- a/src/main/java/com/kqp/inventorytabs/tabs/TabManager.java
+++ b/src/main/java/com/kqp/inventorytabs/tabs/TabManager.java
@@ -220,7 +220,7 @@ public class TabManager {
             if (prevCursorStack != null && !prevCursorStack.isEmpty()) {
                 this.prevCursorStackSlot = client.player.getInventory().getEmptySlot();
 
-                if (this.prevCursorStackSlot != 1 && client.interactionManager != null) {
+                if (this.prevCursorStackSlot != -1 && client.interactionManager != null) {
                     // Put the cursor stack there
                     handler.getSlotIndex(client.player.getInventory(), this.prevCursorStackSlot).ifPresent((screenSlot) -> {
                         client.interactionManager.clickSlot(


### PR DESCRIPTION
When swapping to a new tab, attempts to place the cursor stack in an empty slot (if there is one), saving the slot #. When the new screen initalizes, attempts to pick up from that slot #, placing the stack back on the cursor and clearing the saved slot #.

Side Effects:

 - Item briefly appears in empty slot on high refresh rates (may be able to be remedied by mixing in earlier, e.g. to MinecraftClient.SetScreen)
 - Edge-case race condition between the "click slot" and "close screen" packets can cause the cursor stack to briefly desync (showing stack on the cursor and in the inventory)
   - very difficult to reproduce, but worth keeping an eye on if it's reported on laggy servers. 
   - May be able to be fixed by simply waiting until the cursor stack is empty to close the screen (not sure how to "wait" like this)